### PR TITLE
avoid error when using nvim via CLI

### DIFF
--- a/lua/neov-ime/init.lua
+++ b/lua/neov-ime/init.lua
@@ -386,6 +386,9 @@ end
 
 ---Install the preedit and commit handlers to Neovide.
 M.setup = function()
+  if neovide == nil then
+    return
+  end
   check_version()
 
   ---@diagnostic disable-next-line: undefined-global


### PR DESCRIPTION
Recently I started to use Neovide and loved it, but sometimes I need to use neovim without GUI.